### PR TITLE
Refactor functions to use `testing.TB` interface

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -11,7 +11,7 @@ import (
 	"github.com/synadia-io/jwt-auth-builder.go"
 )
 
-func ResolverFromAuth(t *testing.T, operator authb.Operator) *ResolverConf {
+func ResolverFromAuth(t testing.TB, operator authb.Operator) *ResolverConf {
 	var config ResolverConf
 	config.Resolver.Type = "mem"
 
@@ -40,7 +40,7 @@ type Conf struct {
 // Marshal serializes a Conf into JSON. This is necessary because
 // some permissions setups will have subject wildcards which will
 // serialize incorrectly as JSON.
-func (c Conf) Marshal(t *testing.T) []byte {
+func (c Conf) Marshal(t testing.TB) []byte {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(false)

--- a/ns.go
+++ b/ns.go
@@ -18,7 +18,7 @@ const UserInfoSubj = "$SYS.REQ.USER.INFO"
 // NatsServer represents a nats-server
 type NatsServer struct {
 	sync.Mutex
-	t      *testing.T
+	t      testing.TB
 	Server *server.Server
 	// Resolver *ResolverConf
 	Url   string
@@ -51,7 +51,7 @@ type NatsServer struct {
 //	}
 //}
 
-func NewNatsServer(t *testing.T, opts *server.Options) *NatsServer {
+func NewNatsServer(t testing.TB, opts *server.Options) *NatsServer {
 	ns, u := StartNatsServer(t, opts)
 	return &NatsServer{
 		t:      t,
@@ -60,7 +60,7 @@ func NewNatsServer(t *testing.T, opts *server.Options) *NatsServer {
 	}
 }
 
-func StartNatsServer(t *testing.T, opts *server.Options) (*server.Server, string) {
+func StartNatsServer(t testing.TB, opts *server.Options) (*server.Server, string) {
 	defaults := DefaultNatsServerOptions()
 	if opts == nil {
 		opts = DefaultNatsServerOptions()
@@ -155,7 +155,7 @@ func (ts *NatsServer) Shutdown() {
 	ts.Server.Shutdown()
 }
 
-func ClientInfo(t *testing.T, nc *nats.Conn) UserInfo {
+func ClientInfo(t testing.TB, nc *nats.Conn) UserInfo {
 	r, err := nc.Request(UserInfoSubj, nil, time.Second*2)
 	require.NoError(t, err)
 	require.NotNil(t, r)

--- a/testdir.go
+++ b/testdir.go
@@ -10,11 +10,11 @@ import (
 
 // TestDir a directory  with some simple powers
 type TestDir struct {
-	t   *testing.T
+	t   testing.TB
 	Dir string
 }
 
-func NewTestDir(t *testing.T, dir string, pattern string) *TestDir {
+func NewTestDir(t testing.TB, dir string, pattern string) *TestDir {
 	dirPath, err := os.MkdirTemp(dir, pattern)
 	require.NoError(t, err)
 	return &TestDir{t: t, Dir: dirPath}


### PR DESCRIPTION
Updated all functions to replace *testing.T with testing.TB to allow greater flexibility in testing, including support for subtesting and benchmarks. This change improves the reusability of the test utilities across broader test scenarios.