### PR TITLE
Rename TestLogger to NilLogger for clarity

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -5,25 +5,25 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-type TestLogger struct {
+type NilLogger struct {
 	logger server.Logger
 }
 
 func NewTestLogger() server.Logger {
 	logger := nslogger.NewStdLogger(true, true, true, true, true)
-	return &TestLogger{
+	return &NilLogger{
 		logger: logger,
 	}
 }
 
-func (l *TestLogger) Noticef(format string, v ...interface{}) {}
-func (l *TestLogger) Warnf(format string, v ...interface{})   {}
-func (l *TestLogger) Fatalf(format string, v ...interface{}) {
+func (l *NilLogger) Noticef(format string, v ...interface{}) {}
+func (l *NilLogger) Warnf(format string, v ...interface{})   {}
+func (l *NilLogger) Fatalf(format string, v ...interface{}) {
 	l.logger.Fatalf(format, v...)
 }
 
-func (l *TestLogger) Errorf(format string, v ...interface{}) {
+func (l *NilLogger) Errorf(format string, v ...interface{}) {
 	l.logger.Errorf(format, v...)
 }
-func (l *TestLogger) Debugf(format string, v ...interface{}) {}
-func (l *TestLogger) Tracef(format string, v ...interface{}) {}
+func (l *NilLogger) Debugf(format string, v ...interface{}) {}
+func (l *NilLogger) Tracef(format string, v ...interface{}) {}


### PR DESCRIPTION
This change improves naming consistency and aligns the logger's name with its intended behavior. The new name better reflects the minimal logging functionality provided by this implementation.