### PR TITLE
Rename TestLogger to NilLogger for clarity

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,7 +9,7 @@ type NilLogger struct {
 	logger server.Logger
 }
 
-func NewTestLogger() server.Logger {
+func NewNilLogger() server.Logger {
 	logger := nslogger.NewStdLogger(true, true, true, true, true)
 	return &NilLogger{
 		logger: logger,


### PR DESCRIPTION
This change improves naming consistency and aligns the logger's name with its intended behavior. The new name better reflects the minimal logging functionality provided by this implementation.