### PR TITLE
"Make NilLogger's Errorf method a no-op"

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -21,9 +21,6 @@ func (l *NilLogger) Warnf(format string, v ...interface{})   {}
 func (l *NilLogger) Fatalf(format string, v ...interface{}) {
 	l.logger.Fatalf(format, v...)
 }
-
-func (l *NilLogger) Errorf(format string, v ...interface{}) {
-	l.logger.Errorf(format, v...)
-}
+func (l *NilLogger) Errorf(format string, v ...interface{}) {}
 func (l *NilLogger) Debugf(format string, v ...interface{}) {}
 func (l *NilLogger) Tracef(format string, v ...interface{}) {}


### PR DESCRIPTION
Replaced the Errorf method's implementation in NilLogger with a no-op. This ensures consistency with the intended behavior of NilLogger, which is to suppress logging output. Other methods remain unaffected.