### PR TITLE
Add test for user connection with account credentials

### DIFF
--- a/basics_test.go
+++ b/basics_test.go
@@ -331,4 +331,14 @@ func TestPush(t *testing.T) {
 	r, err := Push(nc, c.JWT())
 	require.NoError(t, err)
 	require.Equal(t, 200, r.PushData.Code)
+
+	// connect user from account c
+	uc, err := c.Users().Add("c", "")
+	require.NoError(t, err)
+	d, err = uc.Creds(time.Hour)
+	require.NoError(t, err)
+
+	nc2 := ns.RequireConnect(nats.UserCredentials(td.WriteFile("c.creds", d)))
+	defer nc.Close()
+	t.Log(nc2.ConnectedUrl())
 }

--- a/basics_test.go
+++ b/basics_test.go
@@ -339,6 +339,6 @@ func TestPush(t *testing.T) {
 	require.NoError(t, err)
 
 	nc2 := ns.RequireConnect(nats.UserCredentials(td.WriteFile("c.creds", d)))
-	defer nc.Close()
+	defer nc2.Close()
 	t.Log(nc2.ConnectedUrl())
 }


### PR DESCRIPTION
This update introduces a test to verify user connections using account-generated credentials. It ensures proper credential handling and connectivity using `nc2`, improving test coverage and reliability.