### PR TITLE
stop TestDir from being removed on test error

### DIFF
--- a/testdir.go
+++ b/testdir.go
@@ -16,7 +16,7 @@ type TestDir struct {
 
 func NewTestDir(t testing.TB, dir string, pattern string) *TestDir {
 	if dir == "" {
-		dir = t.TempDir()
+		dir = os.TempDir()
 	}
 	dirPath, err := os.MkdirTemp(dir, pattern)
 	require.NoError(t, err)


### PR DESCRIPTION
Update `NewTestDir` to use `os.TempDir` instead of `t.TempDir` for temporary directory creation, otherwise t.TempDir aut-removes it on test completion